### PR TITLE
Submit question types appropriately

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,17 +1,13 @@
 import { Form, FormSubmission } from "./api";
-import {
-  FormType,
-  FormSubmissionType,
-  FormQuestionSubmissionType
-} from "./types";
-import { List } from "immutable";
+import { FormType } from "./types";
 
-export function setQuestionSubmission(key, value) {
+export function setQuestionSubmission(key, value, questionType) {
   return {
     type: "SET_QUESTION_SUBMISSION",
     payload: {
       key: key,
-      value: value
+      value: value,
+      questionType: questionType
     }
   };
 }

--- a/src/components/RespondToForm.js
+++ b/src/components/RespondToForm.js
@@ -28,14 +28,26 @@ function generateFormSubmission(
   return new FormSubmissionType({
     formId: form.id,
     questionSubmissions: submissions.map(submission => {
-      return new FormQuestionSubmissionType({
-        questionId: submission.id,
-        string: submission.value
-      });
+      switch (submission.questionType) {
+        case "string":
+          return new FormQuestionSubmissionType({
+            questionId: submission.id,
+            string: submission.value
+          });
+        case "text":
+          return new FormQuestionSubmissionType({
+            questionId: submission.id,
+            text: submission.value
+          });
+        case "boolean":
+          return new FormQuestionSubmissionType({
+            questionId: submission.id,
+            boolean: submission.value
+          });
+      }
     })
   });
 }
-
 function generateSections(
   sections: List<SectionType>,
   submissions: Map<string, QuestionSubmissionType>,

--- a/src/components/RespondToForm/Question.js
+++ b/src/components/RespondToForm/Question.js
@@ -35,7 +35,7 @@ function getQuestionWidget(
   submission: QuestionSubmissionType,
   setSubmission: Function
 ) {
-  const onChange = e => setSubmission(id, e.target.value);
+  const onChange = e => setSubmission(id, e.target.value, type);
   switch (type) {
     case "string":
       return <String value={submission.get("value")} onChange={onChange} />;

--- a/src/containers/RespondToForm.js
+++ b/src/containers/RespondToForm.js
@@ -18,8 +18,8 @@ export const RespondToForm = connect(
     return {
       loadExampleForm: () => dispatch(loadExampleForm()),
       getForm: id => dispatch(getForm(id)),
-      setSubmission: (key, value) => {
-        return dispatch(setQuestionSubmission(key, value));
+      setSubmission: (key, value, questionType) => {
+        return dispatch(setQuestionSubmission(key, value, questionType));
       },
       submitForm: formSubmission => dispatch(submitForm(formSubmission))
     };

--- a/src/encoders.js
+++ b/src/encoders.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { FormSubmissionType, FormQuestionSubmissionType } from "./types";
-import { List } from "immutable";
 
 type ApiQuestionSubmission = {
   question_id: number,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -54,7 +54,8 @@ export default function reducer(model: Model = init, action: { type: Action }) {
         ["submissions", action.payload.key],
         new QuestionSubmissionType({
           id: action.payload.key,
-          value: action.payload.value
+          value: action.payload.value,
+          questionType: action.payload.questionType
         })
       );
     default:

--- a/src/types/QuestionSubmissionType.js
+++ b/src/types/QuestionSubmissionType.js
@@ -2,11 +2,15 @@
 
 import { Record } from "immutable";
 
+type QuestionType = "string" | "text" | "boolean";
+
 export default class QuestionSubmissionType
   extends Record({
     id: 0,
-    value: ""
+    value: "",
+    questionType: "string"
   }) {
   id: number;
   value: string;
+  questionType: QuestionType;
 }


### PR DESCRIPTION
Previously we always sent the question type as string. Now we know which
type we're sending.