### PR TITLE
Changes based on feedback

### DIFF
--- a/src/output_lib/components/AdministerForm/Confirm.js
+++ b/src/output_lib/components/AdministerForm/Confirm.js
@@ -1,0 +1,10 @@
+//@ flow
+
+export default function Confirm(
+  confirmMessage: string,
+  yesFunction: Function,
+  noFunction: Function
+) {
+  let result = confirm(confirmMessage);
+  result ? yesFunction() : noFunction();
+}

--- a/src/output_lib/components/AdministerForm/FriendlyQuestionTypes.js
+++ b/src/output_lib/components/AdministerForm/FriendlyQuestionTypes.js
@@ -1,0 +1,18 @@
+// @flow
+import { Map } from "immutable";
+
+const mapOfTypes = new Map({
+  string: "Single Line Text",
+  text: "Paragraph Text",
+  select: "Dropdown List",
+  radio: "Multiple Choices",
+  boolean: "Yes/No",
+  address: "Address",
+  content: "Content",
+  multiselect: "Multi Select",
+  checkboxes: "Checkboxes"
+});
+
+export default function getFriendlyQuestionType(questionType: string) {
+  return mapOfTypes.get(questionType);
+}

--- a/src/output_lib/components/AdministerForm/QuestionAdmin.js
+++ b/src/output_lib/components/AdministerForm/QuestionAdmin.js
@@ -6,6 +6,7 @@ import ChoicesAdmin from "./ChoicesAdmin";
 import QuestionDependencyAdmin from "./QuestionDependencyAdmin";
 import { DragTypes } from "./DragTypes";
 import { DragSource, DropTarget } from "react-dnd";
+import getFriendlyQuestionType from "./FriendlyQuestionTypes";
 
 const questionSource = {
   beginDrag(props) {
@@ -97,8 +98,6 @@ function renderQuestionType(props) {
   const makeAddress = () => setQuestionType(section.id, question.id, "address");
   const makeContent = () => setQuestionType(section.id, question.id, "content");
   const makeSelect = () => setQuestionType(section.id, question.id, "select");
-  const makeMultiSelect = () =>
-    setQuestionType(section.id, question.id, "multiselect");
   const makeCheckboxes = () =>
     setQuestionType(section.id, question.id, "checkboxes");
   const makeRadio = () => setQuestionType(section.id, question.id, "radio");
@@ -108,39 +107,35 @@ function renderQuestionType(props) {
       <div>
         <button className="pure-button" onClick={makeString}>
           <i className="fa fa-cog" />
-          String
+          {getFriendlyQuestionType("string")}
         </button>
         <button className="pure-button" onClick={makeText}>
           <i className="fa fa-cog" />
-          Text
+          {getFriendlyQuestionType("text")}
         </button>
         <button className="pure-button" onClick={makeBoolean}>
           <i className="fa fa-cog" />
-          Boolean
+          {getFriendlyQuestionType("boolean")}
         </button>
         <button className="pure-button" onClick={makeAddress}>
           <i className="fa fa-cog" />
-          Address
+          {getFriendlyQuestionType("address")}
         </button>
         <button className="pure-button" onClick={makeContent}>
           <i className="fa fa-cog" />
-          Content
+          {getFriendlyQuestionType("content")}
         </button>
         <button className="pure-button" onClick={makeSelect}>
           <i className="fa fa-cog" />
-          Select
-        </button>
-        <button className="pure-button" onClick={makeMultiSelect}>
-          <i className="fa fa-cog" />
-          Multi-Select
+          {getFriendlyQuestionType("select")}
         </button>
         <button className="pure-button" onClick={makeCheckboxes}>
           <i className="fa fa-cog" />
-          Checkboxes
+          {getFriendlyQuestionType("checkboxes")}
         </button>
         <button className="pure-button" onClick={makeRadio}>
           <i className="fa fa-cog" />
-          Radio
+          {getFriendlyQuestionType("radio")}
         </button>
       </div>
     );
@@ -175,7 +170,7 @@ function renderQuestionFields(props) {
     <fieldset className={className}>
       <header>
         {connectDragSource(<i className="fa fa-bars grippy" />)}
-        <small>{question.type}</small>
+        <small>{getFriendlyQuestionType(question.type)}</small>
         <input
           type="text"
           className="labelinput"

--- a/src/output_lib/components/AdministerForm/QuestionAdmin.js
+++ b/src/output_lib/components/AdministerForm/QuestionAdmin.js
@@ -1,28 +1,11 @@
 // @flow
 
 import React from "react";
-import {
-  QuestionDependencyType,
-  SectionType,
-  QuestionType,
-  AddressType
-} from "../../types";
+import { QuestionDependencyType, SectionType, QuestionType } from "../../types";
 import ChoicesAdmin from "./ChoicesAdmin";
 import QuestionDependencyAdmin from "./QuestionDependencyAdmin";
 import { DragTypes } from "./DragTypes";
 import { DragSource, DropTarget } from "react-dnd";
-import {
-  Text,
-  String,
-  Boolean,
-  Address,
-  Content,
-  Select,
-  MultiSelect,
-  Checkboxes,
-  Radio
-} from "../RespondToForm/widgets";
-import { List } from "immutable";
 
 const questionSource = {
   beginDrag(props) {
@@ -350,18 +333,6 @@ function renderQuestionAdminType(
         {validateAs}
         {requiredField}
         {questionDependencies}
-        <div>
-          <h3>Preview</h3>
-          <String
-            id={question.id}
-            content={question.content}
-            placeholder={question.placeholder}
-            onChange={() => {}}
-            errorMessage=""
-            required={false}
-            value=""
-          />
-        </div>
       </div>
     );
   }
@@ -372,16 +343,6 @@ function renderQuestionAdminType(
         {descriptionTextArea}
         {placeholder}
         {requiredField}
-        <div>
-          <h3>Preview</h3>
-          <Text
-            id={question.id}
-            content={question.content}
-            placeholder={question.placeholder}
-            onChange={() => {}}
-            value=""
-          />
-        </div>
       </div>
     );
   }
@@ -391,17 +352,6 @@ function renderQuestionAdminType(
       <div>
         {descriptionTextArea}
         {requiredField}
-        <div>
-          <h3>Preview</h3>
-          <Boolean
-            id={question.id}
-            content={question.content}
-            placeholder={question.placeholder}
-            onChange={() => {}}
-            value=""
-            label={question.label}
-          />
-        </div>
       </div>
     );
   }
@@ -411,16 +361,6 @@ function renderQuestionAdminType(
       <div>
         {descriptionTextArea}
         {requiredField}
-        <div>
-          <h3>Preview</h3>
-          <Address
-            id={question.id}
-            content={question.content}
-            placeholder={question.placeholder}
-            value={new AddressType()}
-            onChange={() => {}}
-          />
-        </div>
       </div>
     );
   }
@@ -429,10 +369,6 @@ function renderQuestionAdminType(
     return (
       <div>
         {descriptionTextArea}
-        <div>
-          <h3>Preview</h3>
-          <Content content={question.content} />
-        </div>
       </div>
     );
   }
@@ -460,16 +396,6 @@ function renderQuestionAdminType(
           setMetadataFieldValue={setMetadataFieldValue}
           reorderChoice={(choiceId, order) => reorderChoice(choiceId, order)}
         />
-        <div>
-          <h4>Preview</h4>
-          <Select
-            content={question.content}
-            value=""
-            id={question.id}
-            onChange={() => {}}
-            choices={question.choices}
-          />
-        </div>
       </div>
     );
   }
@@ -495,17 +421,6 @@ function renderQuestionAdminType(
           setMetadataFieldValue={setMetadataFieldValue}
           reorderChoice={(choiceId, order) => reorderChoice(choiceId, order)}
         />
-        <div>
-          <h4>Preview</h4>
-          <MultiSelect
-            content={question.content}
-            id={question.id}
-            value=""
-            onChange={() => {}}
-            choices={question.choices}
-            values={new List([])}
-          />
-        </div>
       </div>
     );
   }
@@ -530,17 +445,6 @@ function renderQuestionAdminType(
           setMetadataFieldValue={setMetadataFieldValue}
           reorderChoice={(choiceId, order) => reorderChoice(choiceId, order)}
         />
-        <div>
-          <h4>Preview</h4>
-          <Checkboxes
-            content={question.content}
-            id={question.id}
-            value=""
-            label=""
-            onChange={() => {}}
-            choices={question.choices}
-          />
-        </div>
       </div>
     );
   }
@@ -565,16 +469,6 @@ function renderQuestionAdminType(
           setMetadataFieldValue={setMetadataFieldValue}
           reorderChoice={(choiceId, order) => reorderChoice(choiceId, order)}
         />
-        <div>
-          <h4>Preview</h4>
-          <Radio
-            name={`radio-${question.id}`}
-            content={question.content}
-            value={""}
-            onChange={() => {}}
-            choices={question.choices}
-          />
-        </div>
       </div>
     );
   }

--- a/src/output_lib/components/AdministerForm/QuestionAdmin.js
+++ b/src/output_lib/components/AdministerForm/QuestionAdmin.js
@@ -7,6 +7,7 @@ import QuestionDependencyAdmin from "./QuestionDependencyAdmin";
 import { DragTypes } from "./DragTypes";
 import { DragSource, DropTarget } from "react-dnd";
 import getFriendlyQuestionType from "./FriendlyQuestionTypes";
+import Confirm from "./Confirm";
 
 const questionSource = {
   beginDrag(props) {
@@ -187,7 +188,12 @@ function renderQuestionFields(props) {
             className={`expand fa ${editActive}`}
           />
           <i
-            onClick={e => deleteQuestion(section.id, question.id)}
+            onClick={e =>
+              Confirm(
+                "Are you sure?",
+                () => deleteQuestion(section.id, question.id),
+                () => {}
+              )}
             className="fa fa-times-circle-o delete"
           />
         </div>

--- a/src/output_lib/components/AdministerForm/SectionAdmin.js
+++ b/src/output_lib/components/AdministerForm/SectionAdmin.js
@@ -6,6 +6,7 @@ import QuestionAdmin from "./QuestionAdmin";
 import { Set } from "immutable";
 import { DragTypes } from "./DragTypes";
 import { DragSource, DropTarget } from "react-dnd";
+import Confirm from "./Confirm";
 
 type Props = {
   form: Object,
@@ -205,7 +206,12 @@ function SectionAdmin(props: Props) {
               className={`expand fa ${caretClass}`}
             />
             <i
-              onClick={e => deleteSection(section.id)}
+              onClick={e =>
+                Confirm(
+                  "Are you sure?",
+                  () => deleteSection(section.id),
+                  () => {}
+                )}
               className="fa fa-times-circle-o delete"
             />
           </div>

--- a/src/output_lib/components/RespondToForm/widgets/Address.js
+++ b/src/output_lib/components/RespondToForm/widgets/Address.js
@@ -264,6 +264,9 @@ export default function Address(props: Props) {
   const changeState = state => {
     onChange(value.set("state", state));
   };
+  const changeCountry = country => {
+    onChange(value.set("country", country));
+  };
   const changeZip = zip => {
     onChange(value.set("zip", zip));
   };
@@ -285,7 +288,7 @@ export default function Address(props: Props) {
           }}
         />
       </div>
-      <div className="pure-u-1-3">
+      <div className="pure-u-1-4">
         <label htmlFor={id + "-city"}>City:</label>
         <input
           id={id + "-city"}
@@ -299,7 +302,7 @@ export default function Address(props: Props) {
           }}
         />
       </div>
-      <div className="pure-u-1-3">
+      <div className="pure-u-1-4">
         <label htmlFor={id + "-state"}>State:</label>
         <select
           id={id + "-state"}
@@ -318,7 +321,21 @@ export default function Address(props: Props) {
             .toJS()}
         </select>
       </div>
-      <div className="pure-u-1-3">
+      <div className="pure-u-1-4">
+        <label htmlFor={id + "-state"}>Country:</label>
+        <input
+          id={id + "-country"}
+          name={id + "-country"}
+          type="text"
+          placeholder="Country"
+          value={value.country}
+          className="pure-u-23-24"
+          onChange={e => {
+            changeCountry(e.target.value);
+          }}
+        />
+      </div>
+      <div className="pure-u-1-4">
         <label htmlFor={id + "-state"}>Zip:</label>
         <input
           id={id + "-zip"}

--- a/src/output_lib/components/RespondToForm/widgets/Address.test.js
+++ b/src/output_lib/components/RespondToForm/widgets/Address.test.js
@@ -9,6 +9,7 @@ const address = new AddressType({
   street: "Street",
   city: "Birmighan",
   state: "Alabama",
+  country: "USA",
   zip: "5555"
 });
 

--- a/src/output_lib/types/AddressType.js
+++ b/src/output_lib/types/AddressType.js
@@ -7,10 +7,12 @@ export default class AddressType
     street: "",
     city: "",
     state: "",
+    country: "",
     zip: ""
   }) {
   street: string;
   city: string;
   state: string;
+  country: string;
   zip: string;
 }


### PR DESCRIPTION
The following changes:

- Field preview – We are thinking that it makes the most sense to be able to preview the whole form instead of each field and that it would be easy to just embed the response form and the admin form views on the same page.  So basically, we think this can be removed.
- Can we add a confirmation for deleting fields and sections?  Really deleting anything.  Just to keep from accidentally losing everything. 
-  Add Country to the address field block
- Field types – Can we change the names of the field types to:
